### PR TITLE
Added mockChrome object back since it is needed for tests to pass

### DIFF
--- a/src/__tests__/usePopup.tests.ts
+++ b/src/__tests__/usePopup.tests.ts
@@ -2,6 +2,21 @@ import { renderHook, act } from '@testing-library/react';
 import { usePopup } from 'components/usePopup';
 import { CountryName } from '../constants/Countries';
 
+const mockChrome = {
+    tabs: {
+        query: jest.fn(),
+        reload: jest.fn(),
+    },
+    runtime: {
+        onMessage: {
+            addListener: jest.fn(),
+        },
+        sendMessage: jest.fn(),
+    },
+};
+
+(global as any).chrome = mockChrome;
+
 describe('usePopup', () => {
     beforeEach(() => {
         jest.clearAllMocks();


### PR DESCRIPTION
mockChrome object is needed so that the following error is not thrown:

```typescript
usePopup › addSelectedCountry should update selectedCountries

    ReferenceError: chrome is not defined

      42 |
      43 |     useEffect(() => {
    > 44 |         chrome.runtime.onMessage.addListener((message) => {
         |         ^
      45 |             const accumulative = message.transferSize
      46 |             if (accumulative >= 0) {
      47 |                 setTransferSize(transferSize + accumulative);
```