### PR TITLE
22/06/2023 bug set selected countries passed to calculate carbon is not the latest value

### DIFF
--- a/src/components/usePopup.ts
+++ b/src/components/usePopup.ts
@@ -75,18 +75,11 @@ export const usePopup = (): PopupProps => {
     };
 
     const addSelectedCountry = (country: CountryName) => {
-        const newMap = new Map(selectedCountries);
-        if (newMap.has(country)) {
-            return
-        }
-        newMap.set(country, 0);
+        const newMap = new Map(selectedCountries).set(country, 0);
         setSelectedCountries(newMap);
     }
     const removeSelectedCountry = (country: CountryName) => {
         const newMap = new Map(selectedCountries);
-        if (!newMap.has(country)) {
-            return
-        }
         newMap.delete(country);
         setSelectedCountries(newMap);
     }
@@ -108,7 +101,7 @@ export const usePopup = (): PopupProps => {
         return () => {
             chrome.storage.local.onChanged.removeListener(totalBytesReceivedListener);
         }
-    }, []);
+    }, [selectedCountries]);
 
 
     return {

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,8 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-    <script defer src="popup.js"></script>
-    <script defer src="background.js"></script>
   </head>
   <body>
     <div id="react-target"></div>


### PR DESCRIPTION
There are 2 bugs that this PR fixes: 

1. Regardless of which countries the user selects to update selectedCountries, calculateCarbon continues using the default selected country of "World Average". 

The issue was in the following code:
```
const totalBytesReceivedListener = (changes: {
        [key: string]: chrome.storage.StorageChange;
    }) => {
        if (changes.totalBytesReceived) {
            setTotalBytesReceived(changes.totalBytesReceived.newValue);
            setEmissions(calculateCarbon(changes.totalBytesReceived.newValue, selectedCountries));
        }

    }

    useEffect(() => {

        chrome.storage.local.onChanged.addListener(totalBytesReceivedListener);

        return () => {
            chrome.storage.local.onChanged.removeListener(totalBytesReceivedListener);
        }
    }, []);
```
The totalBytesReceivedListener is initialised when the component mounts in useEffect, with the default selected Country "World Average". When the user changes selectedCountry, the UI updates and useEffect is called again, but React does not detect the change in the totalBytesReceivedListener, so it does not initialise it with the updated selectedCountries.

To fix this, selectedCountries was added as a dependency to useEffect, so that it reinitialises the listener with the correct selectedCountries variable:

```
useEffect(() => {

        chrome.storage.local.onChanged.addListener(totalBytesReceivedListener);

        return () => {
            chrome.storage.local.onChanged.removeListener(totalBytesReceivedListener);
        }
    }, [selectedCountries]);
```

2. After fixing this bug, the logs showed that the calculateCarbon function was being called twice, one of them with the latest selectedCountries value (fixed by 1.), but the other calculateCarbon function was called with the "World Average" default value. 

This was caused by the popup.js and background.js being mounted twice, as shown in the `dist` build folder in the following lines:

```
<head>
    ...
    <script defer src="popup.js"></script>
    <script defer src="background.js"></script>
  <script defer src="popup.js"></script><script defer src="background.js"></script></head>
  <body>
```

This was due to the manual mounting of the two components in popup.html, which is unnecessary since the webpack config automatically adds the two components in `webpack.config.js`:

```
module.exports = {
  entry: { popup: "./src/popup.tsx", background: "./src/background.ts" },
```

With these 2 bug fixes, the calculated carbon emissions is now correctly updating 🔥 props to @freddietheodo  