### PR TITLE
FIX: Added sendResponse to fix message channel closed bug

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -51,7 +51,7 @@ const webRequestOnBeforeSendHeaders = (
     }
 };
 
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const { tabId } = message;
 
     if (message.command === "startStoringWebRequestPayloadSize") {
@@ -77,6 +77,6 @@ chrome.runtime.onMessage.addListener((message) => {
             webRequestOnCompleteListener
         );
     }
-
+    sendResponse(true);
     return true;
 });


### PR DESCRIPTION
Fix for bug: 

Uncaught (in promise) Error: A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received


- background.ts.chrome.runtime.onMessage.addListener has three args
  - Message
  - Sender
  - sendResponse: 
    - used to send data back to the chrome.runtime.sendMessage invocation
    - If channel is closed before sender receives response, then can cause issue 