### PR TITLE
2023/07/11-on-Forge-assessment-platform-extension-records-bytes-transferred-if-open-but-does-not-otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 
-
-Getting started with dev:
+## Getting started
 1. `npm install` to install dependencies
-2. `npm run dev` to get webpack to build dist/ folder
+2. `npm run dev` to get webpack to listen for code changes build dist/ folder
 3. Open Chrome
 4. Go to manage extensions
 5. Enable developer mode
 6. Click load unpacked extension
 7. Select the `dist` folder
+
+### Monitoring background processes
+1. Go to Manage Extensions
+2. Look for the Sustainability Calculator extension card
+3. Click on “Inspect views service worker”
 
 
 ## Known Bugs

--- a/src/data/bytes/BytesRepository.ts
+++ b/src/data/bytes/BytesRepository.ts
@@ -6,21 +6,21 @@ export class BytesRepository implements IBytesRepository {
 
     async getTotalBytesTransferred(): Promise<number> {
         const object = await this.remoteDataSource.get({
-            totalBytesTransferred: 0,
+            bytesTransferred: 0,
         });
-        return object.totalBytesTransferred as number;
+        return object.bytesTransferred as number;
     }
 
     async addBytesTransferred(bytes: number): Promise<void> {
         const currentBytes = await this.getTotalBytesTransferred();
         await this.remoteDataSource.set({
-            totalBytesTransferred: currentBytes + bytes,
+            bytesTransferred: currentBytes + bytes,
         });
     }
 
     async clearTotalBytesTransferred(): Promise<void> {
         await this.remoteDataSource.set({
-            totalBytesTransferred: 0,
+            bytesTransferred: 0,
         });
     }
 }

--- a/src/data/calculations/ICalculationsRepository.ts
+++ b/src/data/calculations/ICalculationsRepository.ts
@@ -21,20 +21,20 @@ export abstract class ICalculationsRepository {
         return this._instance;
     }
 
-    abstract storeCalculation(calculationData: CalculationData): Promise<void>;
+    abstract isOngoingCalculation(): Promise<boolean>;
 
-    abstract cacheOngoingCalculation(
-        calculationData: CalculationData
+    abstract setOngoingCalculation(ongoing: boolean): Promise<void>;
+
+    abstract storeCalculation(
+        calculationData: CalculationDataType
     ): Promise<void>;
 
-    abstract clearOngoingCalculation(): Promise<void>;
+    abstract getLastCalculation(): Promise<CalculationDataType | null>;
 
-    abstract getLastCalculation(): Promise<CalculationData | null>;
-
-    abstract getAllCalculations(): Promise<CalculationData[]>;
+    abstract getAllCalculations(): Promise<CalculationDataType[]>;
 }
 
-export type CalculationData = {
+export type CalculationDataType = {
     bytes: number;
     emissions: number;
     specificEmissions: number;

--- a/src/data/calculations/TestCalculationsRepository.ts
+++ b/src/data/calculations/TestCalculationsRepository.ts
@@ -1,35 +1,32 @@
 import {
-    CalculationData,
+    CalculationDataType,
     ICalculationsRepository,
 } from "./ICalculationsRepository";
 
 export class TestCalculationsRepository implements ICalculationsRepository {
-    private _allCalculations: CalculationData[] = [];
-    private _ongoingCalculation: CalculationData | null = null;
+    private _allCalculations: CalculationDataType[] = [];
+    private _ongoingCalculation = false;
 
-    async storeCalculation(calculationData: CalculationData): Promise<void> {
+    async storeCalculation(
+        calculationData: CalculationDataType
+    ): Promise<void> {
         const tempArray = [calculationData, ...this._allCalculations];
         this._allCalculations = tempArray;
     }
 
-    async cacheOngoingCalculation(
-        calculationData: CalculationData
-    ): Promise<void> {
-        this._ongoingCalculation = calculationData;
+    async isOngoingCalculation(): Promise<boolean> {
+        return this._ongoingCalculation;
     }
 
-    async clearOngoingCalculation(): Promise<void> {
-        this._ongoingCalculation = null;
+    async setOngoingCalculation(ongoing: boolean): Promise<void> {
+        this._ongoingCalculation = ongoing;
     }
 
-    async getAllCalculations(): Promise<CalculationData[]> {
+    async getAllCalculations(): Promise<CalculationDataType[]> {
         return this._allCalculations;
     }
 
-    async getLastCalculation(): Promise<CalculationData | null> {
-        if (this._ongoingCalculation !== null) {
-            return this._ongoingCalculation;
-        }
+    async getLastCalculation(): Promise<CalculationDataType | null> {
         if (this._allCalculations.length > 0) {
             return this._allCalculations[0];
         }

--- a/src/data/storage/IStorageRepository.ts
+++ b/src/data/storage/IStorageRepository.ts
@@ -1,7 +1,7 @@
 import { StorageRepository } from "./StorageRepository";
 import { TestStorageRepository } from "./TestStorageRepository";
 
-export type StorageDataType = string | number | null;
+export type StorageDataType = string | number | boolean | null;
 export abstract class IStorageRepository {
     private static _instance: IStorageRepository;
     static get instance(): IStorageRepository {

--- a/src/data/storage/StorageRemoteDataSource.ts
+++ b/src/data/storage/StorageRemoteDataSource.ts
@@ -51,7 +51,9 @@ export class StorageRemoteDataSource {
                 return result;
             });
         } catch (e) {
-            throw new Error("getTotalBytesTransferred failed: " + e);
+            throw new Error(
+                `StorageRemoteDataSource failed to get: ${data}: ${e}`
+            );
         }
     }
 
@@ -59,7 +61,9 @@ export class StorageRemoteDataSource {
         try {
             await this.storage.write(data);
         } catch (e) {
-            throw new Error("addBytesTransferred failed: " + e);
+            throw new Error(
+                `StorageRemoteDataSource failed to set: ${data}: ${e}`
+            );
         }
     }
 
@@ -67,7 +71,7 @@ export class StorageRemoteDataSource {
         try {
             await this.storage.clear();
         } catch (e) {
-            throw new Error("clearTotalBytesTransferred failed: " + e);
+            throw new Error(`StorageRemoteDataSource failed to clear: ${e}`);
         }
     }
 }

--- a/src/view/components/calculation-history/CalculationHistory.tsx
+++ b/src/view/components/calculation-history/CalculationHistory.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { CalculationData } from "../../../data/calculations/ICalculationsRepository";
+import { CalculationDataType } from "../../../data/calculations/ICalculationsRepository";
 type CountryDropdownType = {
     refreshCalculationHistory: () => void;
-    calculationHistory: CalculationData[];
+    calculationHistory: CalculationDataType[];
 };
 export const CalculationHistory = ({
     refreshCalculationHistory,

--- a/src/view/popup/popup.tsx
+++ b/src/view/popup/popup.tsx
@@ -8,7 +8,7 @@ import { formatBytesString } from "./utils/formatBytesString";
 
 export const Popup = () => {
     const {
-        totalBytesTransferred,
+        bytesTransferred,
         emissions,
         selectedCountries,
         addSelectedCountry,
@@ -34,9 +34,7 @@ export const Popup = () => {
                 Calculate CO2 emissions as new user
             </button>
             <button onClick={() => stopRecording()}>Stop calculation</button>
-            <p>
-                Total Data Received: {formatBytesString(totalBytesTransferred)}
-            </p>
+            <p>Total Data Received: {formatBytesString(bytesTransferred)}</p>
             <p>
                 Specific Carbon Emissions:
                 {` ${averageSpecificEmissions.toFixed(

--- a/src/view/popup/usePopup.ts
+++ b/src/view/popup/usePopup.ts
@@ -17,7 +17,7 @@ export const usePopup = () => {
         ICalculationsRepository.instance;
     const bytesRepository: IBytesRepository = IBytesRepository.instance;
 
-    const [totalBytesTransferred, setBytesTransferred] = useState(0);
+    const [bytesTransferred, setBytesTransferred] = useState(0);
     const [emissions, setEmissions] = useState(0);
     const [selectedCountries, setSelectedCountries] = useState<
         Map<CountryName, number>
@@ -124,7 +124,7 @@ export const usePopup = () => {
         });
         try {
             calculationsRepository.storeCalculation({
-                bytes: totalBytesTransferred,
+                bytes: bytesTransferred,
                 emissions: emissions,
                 specificEmissions: averageSpecificEmissions,
                 selectedCountries: selectedCountries,
@@ -155,10 +155,10 @@ export const usePopup = () => {
         const totalBytesTransferredListener = (changes: {
             [key: string]: chrome.storage.StorageChange;
         }) => {
-            if (changes.totalBytesTransferred) {
-                setBytesTransferred(changes.totalBytesTransferred.newValue);
+            if (changes.bytesTransferred) {
+                setBytesTransferred(changes.bytesTransferred.newValue);
                 const _emissions = calculateCarbon(
-                    changes.totalBytesTransferred.newValue,
+                    changes.bytesTransferred.newValue,
                     selectedCountries
                 );
                 setEmissions(_emissions);
@@ -210,7 +210,7 @@ export const usePopup = () => {
 
     return {
         emissions,
-        totalBytesTransferred,
+        bytesTransferred,
         selectedCountries,
         addSelectedCountry,
         removeSelectedCountry,


### PR DESCRIPTION
Bug due to 
- background process updating BytesRepository but not CalculationRepository, 
- so when popup closes and reopens, view is updated with CalculationRepository value but not BytesRepository

Fix implemented:
- when popup closes and reopens, view is updated with bytes from BytesRepository


![temp](https://github.com/Theodo-UK/sustainability-calculator/assets/57725347/479b500a-69dc-4428-a7d5-cc960a7e39e5)
